### PR TITLE
Improve a11y and refactor overlay data

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,11 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends(
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:jsx-a11y/recommended"
+  ),
 ];
 
 export default eslintConfig;

--- a/src/components/ScrollSectionTrigger.tsx
+++ b/src/components/ScrollSectionTrigger.tsx
@@ -16,7 +16,7 @@ export default function ScrollSectionTrigger({
   text,
   direction = 'down',
 }: ScrollSectionTriggerProps) {
-  const triggerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   useLayoutEffect(() => {
     if (!triggerRef.current) return
@@ -46,9 +46,12 @@ export default function ScrollSectionTrigger({
   const Icon = direction === 'down' ? ChevronDown : ChevronUp
 
   return (
-    <div
+    <button
       ref={triggerRef}
       className="relative w-full min-h-screen flex items-center justify-center z-10"
+      onClick={onTrigger}
+      aria-label={text}
+      type="button"
     >
       <motion.div
         initial={{ opacity: 0, y: direction === 'down' ? -20 : 20 }}
@@ -71,6 +74,6 @@ export default function ScrollSectionTrigger({
           <Icon className="w-6 h-6 md:w-7 md:h-7" />
         </motion.div>
       </motion.div>
-    </div>
+    </button>
   )
 }

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -8,7 +8,8 @@ type Props = {
 
 export default function Navbar({ selected, onSelect, canChangeSection, onChangeSection, onNavbarChanged }: Props) {
   const btnClass = (val: string) =>
-    `px-6 py-2 rounded-full transition ${selected === val ? 'bg-white text-black font-bold' : 'bg-black/60 text-white'
+    `px-6 py-2 rounded-full transition focus-visible:outline-none focus-visible:ring focus-visible:ring-white ${
+      selected === val ? 'bg-white text-black font-bold' : 'bg-black/60 text-white'
     }`
   const handleClick = (section: 'before' | 'during' | 'after') => {
     if (!canChangeSection || section === selected) return
@@ -17,10 +18,31 @@ export default function Navbar({ selected, onSelect, canChangeSection, onChangeS
     onSelect(section)
   }
   return (
-    <div className="flex gap-6 bg-black/30 backdrop-blur px-6 py-3 rounded-full shadow-lg ">
-      <button onClick={() => handleClick('before')} className={btnClass('before')}>Before</button>
-      <button onClick={() => handleClick('during')} className={btnClass('during')}>During</button>
-      <button onClick={() => handleClick('after')} className={btnClass('after')}>After</button>
-    </div>
+    <nav className="flex gap-6 bg-black/30 backdrop-blur px-6 py-3 rounded-full shadow-lg">
+      <button
+        onClick={() => handleClick('before')}
+        className={btnClass('before')}
+        aria-current={selected === 'before' ? 'page' : undefined}
+        type="button"
+      >
+        Before
+      </button>
+      <button
+        onClick={() => handleClick('during')}
+        className={btnClass('during')}
+        aria-current={selected === 'during' ? 'page' : undefined}
+        type="button"
+      >
+        During
+      </button>
+      <button
+        onClick={() => handleClick('after')}
+        className={btnClass('after')}
+        aria-current={selected === 'after' ? 'page' : undefined}
+        type="button"
+      >
+        After
+      </button>
+    </nav>
   )
 }

--- a/src/data/overlays.tsx
+++ b/src/data/overlays.tsx
@@ -1,0 +1,230 @@
+import type { OverlayItem } from '@/types/overlay'
+
+export const beforeOverlays: OverlayItem[] = [
+  {
+    key: 'before-1',
+    appear: 1,
+    disappear: 3,
+    align: 'top left',
+    type: 'info',
+    content: (
+      <p className="text-sm">
+        📝 Coordination initiated with local authorities and emergency agencies ahead of landfall.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'before-2',
+    appear: 3,
+    disappear: 5,
+    align: 'bottom right',
+    type: 'success',
+    content: (
+      <p className="text-sm">
+        ✅ Emergency shelters inspected and stocked with essential supplies.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'before-3',
+    appear: 5,
+    disappear: 7,
+    align: 'top right',
+    type: 'warning',
+    content: (
+      <p className="text-sm">
+        ⚠️ Public briefing issued: residents advised to secure homes and prepare for prolonged outages.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'before-4',
+    appear: 7,
+    disappear: 10,
+    align: 'center',
+    type: 'error',
+    content: (
+      <p className="text-sm font-medium">
+        📡 Communications tested between command centers to ensure readiness.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'before-5',
+    appear: 10,
+    disappear: 13,
+    align: 'bottom left',
+    type: 'info',
+    content: (
+      <p className="text-sm">
+        🧭 Evacuation routes identified and shared with community leaders.
+      </p>
+    ),
+    withIcon: false,
+  },
+];
+
+export const duringOverlays: OverlayItem[] = [
+  {
+    key: 'during-1',
+    appear: 1,
+    disappear: 4,
+    align: 'top',
+    type: 'error',
+    content: (
+      <p className="text-sm font-semibold">
+        🚨 Hurricane Beryl made landfall causing widespread power outages and structural damage.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'during-2',
+    appear: 4,
+    disappear: 7,
+    align: 'bottom right',
+    type: 'info',
+    content: (
+      <div className="flex flex-col text-sm">
+        <span className="font-medium">📍 Real-time assessments launched</span>
+        <span className="opacity-80">Initial field data captured via drones and mobile teams.</span>
+      </div>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'during-3',
+    appear: 7,
+    disappear: 10,
+    align: 'top left',
+    type: 'success',
+    content: (
+      <p className="text-sm">👷 Emergency responders deployed in affected areas for structural inspections.</p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'during-4',
+    appear: 10,
+    disappear: 13,
+    align: 'center',
+    type: 'info',
+    content: (
+      <p className="font-semibold text-base">
+        📡 Satellite imagery analysis in progress to guide targeted relief.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'during-5',
+    appear: 13,
+    disappear: 16,
+    align: 'bottom left',
+    type: 'warning',
+    content: (
+      <p className="text-sm">
+        ⚠️ Road blockages and debris reported across Saint Vincent and the Grenadines.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'during-6',
+    appear: 16,
+    disappear: 19,
+    align: 'top right',
+    type: 'error',
+    content: (
+      <span className="text-xs">
+        📞 Emergency communication lines activated for civilian reporting and aid coordination.
+      </span>
+    ),
+    withIcon: false,
+  },
+];
+
+export const afterOverlays: OverlayItem[] = [
+  {
+    key: 'after-1',
+    appear: 1,
+    disappear: 4,
+    align: 'top left',
+    type: 'success',
+    content: (
+      <p className="text-sm">
+        ✅ Initial assessment: majority of critical infrastructure remains operational.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'after-2',
+    appear: 4,
+    disappear: 7,
+    align: 'center',
+    type: 'info',
+    content: (
+      <p className="text-sm font-medium">
+        🧑‍💼 Damage evaluation teams deployed across affected regions.
+      </p>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'after-3',
+    appear: 7,
+    disappear: 10,
+    align: 'bottom right',
+    type: 'warning',
+    content: (
+      <div className="text-sm">
+        🏚️ Over 2,000 structures identified with roof or wall damage.
+      </div>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'after-4',
+    appear: 10,
+    disappear: 13,
+    align: 'top right',
+    type: 'error',
+    content: (
+      <div className="text-sm">
+        🧹 Debris clearance underway — priority on major roads and public areas.
+      </div>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'after-5',
+    appear: 13,
+    disappear: 16,
+    align: 'bottom left',
+    type: 'success',
+    content: (
+      <div className="text-sm">
+        🙌 Community volunteers actively supporting relief distribution efforts.
+      </div>
+    ),
+    withIcon: false,
+  },
+  {
+    key: 'after-6',
+    appear: 16,
+    disappear: 19,
+    align: 'center',
+    type: 'info',
+    content: (
+      <p className="text-sm font-semibold text-center">
+        📊 Post-event data collection in progress to support long-term recovery planning.
+      </p>
+    ),
+    withIcon: false,
+  },
+];

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -2,16 +2,21 @@
 
 import { motion } from 'framer-motion'
 import { AlertTriangle, ChevronDown } from 'lucide-react'
+import Image from 'next/image'
 
 export default function HeroSection() {
   return (
     <section
       id="hero"
-      className="h-screen bg-cover bg-center relative flex flex-col items-center justify-center text-center px-4"
-      style={{
-        backgroundImage: 'url(/hero.jpg)', // veille à avoir une image sombre et évocatrice
-      }}
+      className="relative h-screen flex flex-col items-center justify-center text-center px-4"
     >
+      <Image
+        src="/hero.jpg"
+        alt="Satellite view of Hurricane Beryl at night"
+        fill
+        className="object-cover"
+        priority
+      />
       {/* Overlay foncé pour lisibilité */}
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm z-0" />
 

--- a/src/sections/after/AfterSection.tsx
+++ b/src/sections/after/AfterSection.tsx
@@ -6,96 +6,14 @@ import IntroSection from './IntroSection'
 import OutroSection from './OutroSection'
 import { renderOverlays } from '@/utils/overlayUtils'
 import { useMemo } from 'react'
+import { afterOverlays } from '@/data/overlays'
 
 type Props = {
   onBack: () => void
 }
 
 export default function AfterSection({ onBack }: Props) {
-  const overlays = useMemo(
-    () =>
-      renderOverlays([
-        {
-          key: 'after-1',
-          appear: 1,
-          disappear: 4,
-          align: 'top left',
-          type: 'success',
-          content: (
-            <p className="text-sm">
-              ✅ Initial assessment: majority of critical infrastructure remains operational.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'after-2',
-          appear: 4,
-          disappear: 7,
-          align: 'center',
-          type: 'info',
-          content: (
-            <p className="text-sm font-medium">
-              🧑‍💼 Damage evaluation teams deployed across affected regions.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'after-3',
-          appear: 7,
-          disappear: 10,
-          align: 'bottom right',
-          type: 'warning',
-          content: (
-            <div className="text-sm">
-              🏚️ Over 2,000 structures identified with roof or wall damage.
-            </div>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'after-4',
-          appear: 10,
-          disappear: 13,
-          align: 'top right',
-          type: 'error',
-          content: (
-            <div className="text-sm">
-              🧹 Debris clearance underway — priority on major roads and public areas.
-            </div>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'after-5',
-          appear: 13,
-          disappear: 16,
-          align: 'bottom left',
-          type: 'success',
-          content: (
-            <div className="text-sm">
-              🙌 Community volunteers actively supporting relief distribution efforts.
-            </div>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'after-6',
-          appear: 16,
-          disappear: 19,
-          align: 'center',
-          type: 'info',
-          content: (
-            <p className="text-sm font-semibold text-center">
-              📊 Post-event data collection in progress to support long-term recovery planning.
-            </p>
-          ),
-          withIcon: false,
-        },
-      ]),
-    []
-  )
+  const overlays = useMemo(() => renderOverlays(afterOverlays), [])
 
   return (
     <>

--- a/src/sections/before/BeforeSection.tsx
+++ b/src/sections/before/BeforeSection.tsx
@@ -6,83 +6,14 @@ import OutroSection from './OutroSection'
 import ScrollSectionTrigger from '@/components/ScrollSectionTrigger'
 import { renderOverlays } from '@/utils/overlayUtils'
 import { useMemo } from 'react'
+import { beforeOverlays } from '@/data/overlays'
 
 type Props = {
   onNext: () => void
 }
 
 export default function BeforeSection({ onNext }: Props) {
-  const overlays = useMemo(
-    () =>
-      renderOverlays([
-        {
-          key: 'before-1',
-          appear: 1,
-          disappear: 3,
-          align: 'top left',
-          type: 'info',
-          content: (
-            <p className="text-sm">
-              📝 Coordination initiated with local authorities and emergency agencies ahead of landfall.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'before-2',
-          appear: 3,
-          disappear: 5,
-          align: 'bottom right',
-          type: 'success',
-          content: (
-            <p className="text-sm">
-              ✅ Emergency shelters inspected and stocked with essential supplies.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'before-3',
-          appear: 5,
-          disappear: 7,
-          align: 'top right',
-          type: 'warning',
-          content: (
-            <p className="text-sm">
-              ⚠️ Public briefing issued: residents advised to secure homes and prepare for prolonged outages.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'before-4',
-          appear: 7,
-          disappear: 10,
-          align: 'center',
-          type: 'error',
-          content: (
-            <p className="text-sm font-medium">
-              📡 Communications tested between command centers to ensure readiness.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'before-5',
-          appear: 10,
-          disappear: 13,
-          align: 'bottom left',
-          type: 'info',
-          content: (
-            <p className="text-sm">
-              🧭 Evacuation routes identified and shared with community leaders.
-            </p>
-          ),
-          withIcon: false,
-        },
-      ]),
-    []
-  )
+  const overlays = useMemo(() => renderOverlays(beforeOverlays), [])
 
   return (
     <>

--- a/src/sections/during/DuringSection.tsx
+++ b/src/sections/during/DuringSection.tsx
@@ -6,6 +6,7 @@ import IntroSection from './IntroSection'
 import OutroSection from './OutroSection'
 import { renderOverlays } from '@/utils/overlayUtils'
 import { useMemo } from 'react'
+import { duringOverlays } from '@/data/overlays'
 
 type Props = {
   onNext: () => void
@@ -13,89 +14,7 @@ type Props = {
 }
 
 export default function DuringSection({ onNext, onBack }: Props) {
-  const overlays = useMemo(
-    () =>
-      renderOverlays([
-        {
-          key: 'during-1',
-          appear: 1,
-          disappear: 4,
-          align: 'top',
-          type: 'error',
-          content: (
-            <p className="text-sm font-semibold">
-              🚨 Hurricane Beryl made landfall causing widespread power outages and structural damage.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'during-2',
-          appear: 4,
-          disappear: 7,
-          align: 'bottom right',
-          type: 'info',
-          content: (
-            <div className="flex flex-col text-sm">
-              <span className="font-medium">📍 Real-time assessments launched</span>
-              <span className="opacity-80">Initial field data captured via drones and mobile teams.</span>
-            </div>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'during-3',
-          appear: 7,
-          disappear: 10,
-          align: 'top left',
-          type: 'success',
-          content: (
-            <p className="text-sm">👷 Emergency responders deployed in affected areas for structural inspections.</p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'during-4',
-          appear: 10,
-          disappear: 13,
-          align: 'center',
-          type: 'info',
-          content: (
-            <p className="font-semibold text-base">
-              📡 Satellite imagery analysis in progress to guide targeted relief.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'during-5',
-          appear: 13,
-          disappear: 16,
-          align: 'bottom left',
-          type: 'warning',
-          content: (
-            <p className="text-sm">
-              ⚠️ Road blockages and debris reported across Saint Vincent and the Grenadines.
-            </p>
-          ),
-          withIcon: false,
-        },
-        {
-          key: 'during-6',
-          appear: 16,
-          disappear: 19,
-          align: 'top right',
-          type: 'error',
-          content: (
-            <span className="text-xs">
-              📞 Emergency communication lines activated for civilian reporting and aid coordination.
-            </span>
-          ),
-          withIcon: false,
-        },
-      ]),
-    []
-  )
+  const overlays = useMemo(() => renderOverlays(duringOverlays), [])
 
   return (
     <>

--- a/src/types/overlay.ts
+++ b/src/types/overlay.ts
@@ -14,5 +14,17 @@ export type OverlayAlign =
   | 'bottom left'
   | 'bottom right'
 
+import { ReactNode } from 'react'
+
 export type OverlayType = 'info' | 'warning' | 'success' | 'error'
+
+export interface OverlayItem {
+  key: string
+  appear: number
+  disappear: number
+  align: OverlayAlign
+  type: OverlayType
+  content: ReactNode
+  withIcon?: boolean
+}
 

--- a/src/utils/overlayUtils.tsx
+++ b/src/utils/overlayUtils.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, Info, CheckCircle2, XOctagon } from 'lucide-react'
 import Overlay from '@/components/Overlay'
-import { OverlayAlign, OverlayType } from '@/types/overlay'
+import type { OverlayAlign, OverlayType, OverlayItem } from '@/types/overlay'
 
 const baseOverlayClass = 'px-4 py-3 rounded-lg shadow-lg text-sm flex flex-col items-center gap-1 text-center sm:flex-row sm:gap-2 sm:text-left'
 
@@ -41,17 +41,7 @@ export function renderOverlay(
   )
 }
 
-export function renderOverlays(
-  items: {
-    key: string
-    appear: number
-    disappear: number
-    align: OverlayAlign
-    type: OverlayType
-    content: React.ReactNode
-    withIcon?: boolean
-  }[]
-) {
+export function renderOverlays(items: OverlayItem[]) {
   return items.map(item =>
     renderOverlay(
       item.key,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
## Summary
- enable JSX a11y linting
- create shared overlay configuration
- refactor Before/During/After sections to use overlay data
- add Tailwind and Prettier configs
- improve navbar and scroll trigger accessibility
- convert hero background to Next Image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bf1cf0208832cb5d7d113fde0a464